### PR TITLE
Add CO2 tolerance training & breath-hold science content

### DIFF
--- a/SocraticJournal.xcodeproj/project.pbxproj
+++ b/SocraticJournal.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		54BD24D0AB6F3F961A2A7BE3 /* NotificationServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26B1FE888678C875F331DB1 /* NotificationServiceProtocol.swift */; };
 		558BAEE1F00DB0BD73CF869D /* ProgramCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9D53BA27D2C984BB8128B /* ProgramCarousel.swift */; };
 		55B60718FE227BEA19D64946 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DC2F15103B1EED7B1CFB9157 /* GoogleService-Info.plist */; };
+		55CAEC06EFE649520A187678 /* LearnContentChapter5Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994341E60AB81D1EAB48D639 /* LearnContentChapter5Tests.swift */; };
 		5A38F686BDEF3AA914881906 /* BreathPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A8B02F05534B87C324BF7A /* BreathPattern.swift */; };
 		5A48F506445202574EF5599C /* MockBreathSessionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4078E7E4011E4189AB3AF43 /* MockBreathSessionRepository.swift */; };
 		5B4EFE058F2587059FFF78A7 /* SocraticJournalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E617F0BC7495BAD6CDDC075B /* SocraticJournalTests.swift */; };
@@ -70,6 +71,7 @@
 		91155306582B4B7662CE72D8 /* UserDefaultsBreathSessionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C1481B20C2C27E606631D /* UserDefaultsBreathSessionRepository.swift */; };
 		9162787D7DD1219552768117 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905280F906AF00098A4D2C8D /* TodayViewModel.swift */; };
 		9163C53633F2F027735054AF /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9E98B9AB99203807F249A5 /* TodayView.swift */; };
+		937F0CDB98A028F0A190CFA9 /* TrainingSectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BFFE3490B9649A1BB25F58 /* TrainingSectionsTests.swift */; };
 		9432AB79D361DC0D1565FBCE /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E120F2C186571C0398EB66 /* UserSettingsTests.swift */; };
 		9642579B660C2F7F7F23E410 /* HapticRhythmEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E9F8E59F56730033FF0309 /* HapticRhythmEngine.swift */; };
 		97DB0893F432AAA1FF3FF082 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = D0C775AF90C1F520FA648805 /* FirebaseFirestore */; };
@@ -100,6 +102,7 @@
 		DCF997669CC191CD3455BBFE /* PatternInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302C0F83D5747A73A08F0A83 /* PatternInfoSection.swift */; };
 		DD8DFAC53005D236FC5C1D7A /* AnalyticsServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FB591A7450FBB08651043F /* AnalyticsServiceProtocol.swift */; };
 		E22D51C2108FCDF5D2670EE7 /* BreathSessionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DF4448F47B1DE6B53169BA /* BreathSessionRepositoryProtocol.swift */; };
+		E533CE6002D70D53EB469BBE /* TrainingDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5590657907E0A3FFE2D5478C /* TrainingDataTests.swift */; };
 		E594F9C12B3734F2ED86CA78 /* MockNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264BBCCB81D25B4C291BDD2D /* MockNotificationService.swift */; };
 		E7BEF20A03B5A2CED4D70D57 /* UserDefaultsSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788820DA9BA9F743A9811730 /* UserDefaultsSettingsRepository.swift */; };
 		ECBF68F49D8770745CCFC556 /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EEB68AC65A76154DCF7B45 /* HealthKitService.swift */; };
@@ -107,6 +110,7 @@
 		EF3B206491149A9F1A72B942 /* AllBOLTScoresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BC7C06001550AF6E252970 /* AllBOLTScoresView.swift */; };
 		F395480855579B6811747877 /* ProgressHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960CC5ACE3BD13E1D11AE13F /* ProgressHistoryView.swift */; };
 		F3DEB15037827CF12B5A4DC3 /* AllSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A013B837B3B1727A13F29B /* AllSessionsView.swift */; };
+		F6581E5A0E3A776B8918DCBD /* TrainingPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C16C3FEF9624531C27B272 /* TrainingPersistenceTests.swift */; };
 		F7A6ACD01D3F048108B098D9 /* SessionCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FAEEA14D3D56EA59B71874A /* SessionCompletionTests.swift */; };
 		FD764235B722DD5F364C9850 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 7427E0C3061E854EE474F549 /* FirebaseMessaging */; };
 		FFD6A44603614E7B7C030FAC /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 20CC8584D9C7E0C1B74D5D56 /* FirebaseFunctions */; };
@@ -133,6 +137,7 @@
 		18EEB68AC65A76154DCF7B45 /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
 		1D851063D549EC1BA61C70FD /* ProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewModel.swift; sourceTree = "<group>"; };
 		21B81A264A8ED07DAB0C5671 /* BreathWaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathWaveView.swift; sourceTree = "<group>"; };
+		25BFFE3490B9649A1BB25F58 /* TrainingSectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingSectionsTests.swift; sourceTree = "<group>"; };
 		264BBCCB81D25B4C291BDD2D /* MockNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationService.swift; sourceTree = "<group>"; };
 		2CF73C946A4299853FE58E44 /* AppSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSpacing.swift; sourceTree = "<group>"; };
 		302C0F83D5747A73A08F0A83 /* PatternInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternInfoSection.swift; sourceTree = "<group>"; };
@@ -149,6 +154,7 @@
 		4C2DE432B9DE5251217EE654 /* SummaryStatsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatsRow.swift; sourceTree = "<group>"; };
 		5116538D9F07FF35490DCEC7 /* SocraticJournal.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SocraticJournal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		54BA9804A6F548EFB32161C7 /* BreathPatternTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathPatternTests.swift; sourceTree = "<group>"; };
+		5590657907E0A3FFE2D5478C /* TrainingDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingDataTests.swift; sourceTree = "<group>"; };
 		55BA781ACCE79EACDA7E0CEE /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		58368D6FA3A29D6D8E4C7C51 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		5B64781DF590E431DB8C4524 /* HealthKitServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitServiceProtocol.swift; sourceTree = "<group>"; };
@@ -183,6 +189,7 @@
 		97421CF4D431F17EAB167925 /* PhaseLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhaseLabelView.swift; sourceTree = "<group>"; };
 		98DEC87C4C78120D2D66BF2D /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		98ED72A3641AD9929F18D8AB /* BOLTInstructionsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BOLTInstructionsPage.swift; sourceTree = "<group>"; };
+		994341E60AB81D1EAB48D639 /* LearnContentChapter5Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnContentChapter5Tests.swift; sourceTree = "<group>"; };
 		9CA3E1F2B8FB060A9055025B /* AppTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTypography.swift; sourceTree = "<group>"; };
 		9DD78B7172A96E20384AA795 /* DailyLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyLog.swift; sourceTree = "<group>"; };
 		9F4B1E73960A7489D123CF41 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
@@ -196,6 +203,7 @@
 		ADC6F17D0DA7224FE57502A0 /* BOLTTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BOLTTestView.swift; sourceTree = "<group>"; };
 		B26B1FE888678C875F331DB1 /* NotificationServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceProtocol.swift; sourceTree = "<group>"; };
 		B67545F72405599CA3D6E892 /* FirebaseNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseNotificationService.swift; sourceTree = "<group>"; };
+		B6C16C3FEF9624531C27B272 /* TrainingPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingPersistenceTests.swift; sourceTree = "<group>"; };
 		B6C8AA2807811F1C4E1165F7 /* BOLTScoreCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BOLTScoreCard.swift; sourceTree = "<group>"; };
 		B8A013B837B3B1727A13F29B /* AllSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllSessionsView.swift; sourceTree = "<group>"; };
 		B8CC51B11D11256E62F9C6E0 /* ProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewModelTests.swift; sourceTree = "<group>"; };
@@ -336,6 +344,16 @@
 				E9721DD221539E97DDD9E989 /* wisdom_quotes.json */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		2CC40DB46FC883038FD7C454 /* Training */ = {
+			isa = PBXGroup;
+			children = (
+				5590657907E0A3FFE2D5478C /* TrainingDataTests.swift */,
+				B6C16C3FEF9624531C27B272 /* TrainingPersistenceTests.swift */,
+				25BFFE3490B9649A1BB25F58 /* TrainingSectionsTests.swift */,
+			);
+			path = Training;
 			sourceTree = "<group>";
 		};
 		3292427AC674B121CCABA44F /* Theme */ = {
@@ -488,6 +506,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		933D8E6BFAD081A5249FFAD4 /* Learn */ = {
+			isa = PBXGroup;
+			children = (
+				994341E60AB81D1EAB48D639 /* LearnContentChapter5Tests.swift */,
+			);
+			path = Learn;
+			sourceTree = "<group>";
+		};
 		9440E899341B6D5D2E0624AC /* Breathe */ = {
 			isa = PBXGroup;
 			children = (
@@ -547,8 +573,10 @@
 				E617F0BC7495BAD6CDDC075B /* SocraticJournalTests.swift */,
 				02CB119E3E1EBA4E94DD78F6 /* Data */,
 				9F90D645532A37147AFA206B /* Domain */,
+				933D8E6BFAD081A5249FFAD4 /* Learn */,
 				6EB5B00B770E1A7C2F23849A /* Mocks */,
 				8E1B325900532C228D0E0B40 /* Presentation */,
+				2CC40DB46FC883038FD7C454 /* Training */,
 			);
 			name = SocraticJournalTests;
 			path = Tests/SocraticJournalTests;
@@ -745,6 +773,7 @@
 				EF2DCE222330B94D6C0CA97E /* BreathSessionTests.swift in Sources */,
 				12C1D195547BA88598851076 /* BreatheViewModelTests.swift in Sources */,
 				1DB64DE4DC0030FFEF1052F1 /* DailyLogTests.swift in Sources */,
+				55CAEC06EFE649520A187678 /* LearnContentChapter5Tests.swift in Sources */,
 				D6081F0B24B69FC0BFCCC4ED /* MockAnalyticsService.swift in Sources */,
 				5A48F506445202574EF5599C /* MockBreathSessionRepository.swift in Sources */,
 				E594F9C12B3734F2ED86CA78 /* MockNotificationService.swift in Sources */,
@@ -754,6 +783,9 @@
 				F7A6ACD01D3F048108B098D9 /* SessionCompletionTests.swift in Sources */,
 				5B4EFE058F2587059FFF78A7 /* SocraticJournalTests.swift in Sources */,
 				ACC7044849214F31BDD663C1 /* TodayViewModelTests.swift in Sources */,
+				E533CE6002D70D53EB469BBE /* TrainingDataTests.swift in Sources */,
+				F6581E5A0E3A776B8918DCBD /* TrainingPersistenceTests.swift in Sources */,
+				937F0CDB98A028F0A190CFA9 /* TrainingSectionsTests.swift in Sources */,
 				9432AB79D361DC0D1565FBCE /* UserSettingsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/SocraticJournal/Domain/Entities/BOLTScore.swift
+++ b/Sources/SocraticJournal/Domain/Entities/BOLTScore.swift
@@ -56,15 +56,15 @@ public enum BOLTTier: String, Codable, Sendable {
     public var interpretation: String {
         switch self {
         case .veryLow:
-            return "Your CO₂ tolerance is very low — this is common in chronic mouth-breathers and people with anxiety. Buteyko Reduced breathing is your priority pattern. Even a few weeks of practice can dramatically improve this score."
+            return "Your CO₂ tolerance is very low — this is common in chronic mouth-breathers and people with anxiety. Buteyko Reduced breathing is your priority pattern. Even a few weeks of practice can dramatically improve this score. Try the CO₂ Tolerance Builder and High Altitude Hold exercises to begin retraining your chemoreceptors."
         case .belowAverage:
-            return "Below average, but this is where most modern adults land. Your chemoreceptors are over-sensitive to CO₂, causing you to over-breathe. Resonance and Coherent patterns will gradually recalibrate."
+            return "Below average, but this is where most modern adults land. Your chemoreceptors are over-sensitive to CO₂, causing you to over-breathe. Resonance and Coherent patterns will gradually recalibrate. The Breath-Hold Walk and CO₂ Tolerance Builder are ideal at this stage — movement during holds accelerates adaptation."
         case .average:
-            return "Average range. You have reasonable CO₂ tolerance but there's significant room for growth. Regular practice with any pattern will improve this. Aim for 30+ as your next milestone."
+            return "Average range. You have reasonable CO₂ tolerance but there's significant room for growth. Regular practice with any pattern will improve this. Aim for 30+ as your next milestone. The CO₂ Table and Apnea Pyramid will challenge your chemoreceptors at this level."
         case .good:
-            return "Good CO₂ tolerance. Your breathing efficiency is above average. You'll notice this in better sleep, lower resting heart rate, and calmer stress response. Keep going — 40+ is excellent."
+            return "Good CO₂ tolerance. Your breathing efficiency is above average. You'll notice this in better sleep, lower resting heart rate, and calmer stress response. Keep going — 40+ is excellent. The CO₂ Table and Apnea Pyramid can push you further toward the excellent range."
         case .excellent:
-            return "Excellent. This indicates strong parasympathetic tone, efficient gas exchange, and well-calibrated chemoreceptors. Nestor found that experienced meditators and free divers consistently score here."
+            return "Excellent. This indicates strong parasympathetic tone, efficient gas exchange, and well-calibrated chemoreceptors. Nestor found that experienced meditators and free divers consistently score here. Maintain your edge with any CO₂ tolerance exercise — the freediver-level protocols will keep your chemoreceptors sharp."
         }
     }
 

--- a/Sources/SocraticJournal/Presentation/Learn/Components/TrainingGrid.swift
+++ b/Sources/SocraticJournal/Presentation/Learn/Components/TrainingGrid.swift
@@ -5,7 +5,7 @@
 #if os(iOS)
 import SwiftUI
 
-/// 2x2 grid of training exercise cards for the Learn tab
+/// Grid of training exercise cards organized by section for the Learn tab
 struct TrainingGrid: View {
     let onSelectExercise: (TrainingData.Exercise) -> Void
 
@@ -15,23 +15,40 @@ struct TrainingGrid: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppSpacing.sm) {
-            Text("TRAINING")
-                .font(.system(size: 11))
-                .tracking(1.0)
-                .foregroundStyle(AppColors.textTertiary)
-                .padding(.horizontal, AppSpacing.screenPadding)
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            ForEach(TrainingData.allSections) { section in
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    // Section header
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(section.title.uppercased())
+                            .font(.system(size: 11))
+                            .tracking(1.0)
+                            .foregroundStyle(AppColors.textTertiary)
 
-            LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(TrainingData.allExercises) { exercise in
-                    TrainingExerciseCard(
-                        exercise: exercise,
-                        completionCount: TrainingData.completionCount(for: exercise.id),
-                        onTap: { onSelectExercise(exercise) }
-                    )
+                        Text(section.subtitle)
+                            .font(.system(size: 12, design: .serif))
+                            .foregroundStyle(AppColors.textSecondary)
+                    }
+                    .padding(.horizontal, AppSpacing.screenPadding)
+
+                    // Teal divider
+                    Rectangle()
+                        .fill(AppColors.accent)
+                        .frame(height: 0.5)
+                        .padding(.horizontal, AppSpacing.screenPadding)
+
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(section.exercises) { exercise in
+                            TrainingExerciseCard(
+                                exercise: exercise,
+                                completionCount: TrainingData.completionCount(for: exercise.id),
+                                onTap: { onSelectExercise(exercise) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.screenPadding)
                 }
             }
-            .padding(.horizontal, AppSpacing.screenPadding)
         }
         .padding(.vertical, AppSpacing.md)
     }

--- a/Sources/SocraticJournal/Presentation/Learn/LearnContent.swift
+++ b/Sources/SocraticJournal/Presentation/Learn/LearnContent.swift
@@ -14,7 +14,7 @@ enum LearnContent {
     }
 
     struct Article: Identifiable {
-        let id: Int // Global article index (0-11)
+        let id: Int // Global article index (0-15)
         let title: String
         let subtitle: String
         let tag: String
@@ -41,9 +41,13 @@ enum LearnContent {
         QuickFact(value: "70%", label: "of breathing should be nasal"),
         QuickFact(value: "4x", label: "more NO via humming"),
         QuickFact(value: "20%", label: "more O\u{2082} via nose"),
+        QuickFact(value: "40s+", label: "excellent BOLT score"),
+        QuickFact(value: "50%", label: "larger Bajau spleens"),
+        QuickFact(value: "80%", label: "of apnea is mental"),
+        QuickFact(value: "10\u{2013}25%", label: "heart rate drop in dive reflex"),
     ]
 
-    // MARK: - Chapters (4 chapters, 12 articles total)
+    // MARK: - Chapters (5 chapters, 16 articles total)
 
     static let chapters: [Chapter] = [
         // Chapter 1: Foundations
@@ -131,7 +135,7 @@ enum LearnContent {
                     tag: "Counter-intuitive",
                     tagColorHex: "7A6030",
                     readTime: "4 min",
-                    body: "The Bohr Effect: oxygen clings more tightly to haemoglobin when CO\u{2082} is high. If you over-breathe and deplete CO\u{2082}, paradoxically less oxygen is released to your tissues. Buteyko\u{2019}s entire system is built on this insight. The chronic \u{2018}air hunger\u{2019} anxiety sufferers feel is usually not a lack of oxygen \u{2014} it\u{2019}s a trained intolerance to CO\u{2082}. Slow, reduced breathing rebuilds this tolerance over weeks. The practical test is the BOLT score (Body Oxygen Level Test): after a normal exhale, time how long until you feel the first urge to breathe. Most untrained people score 15-20 seconds. Patrick McKeown\u{2019}s Buteyko training aims for 40+. The improvement curve is steep \u{2014} a few weeks of reduced-volume breathing can add 10-15 seconds to your BOLT score."
+                    body: "The Bohr Effect: oxygen clings more tightly to haemoglobin when CO\u{2082} is high. If you over-breathe and deplete CO\u{2082}, paradoxically less oxygen is released to your tissues. Buteyko\u{2019}s entire system is built on this insight. The chronic \u{2018}air hunger\u{2019} anxiety sufferers feel is usually not a lack of oxygen \u{2014} it\u{2019}s a trained intolerance to CO\u{2082}. Slow, reduced breathing rebuilds this tolerance over weeks. The practical test is the BOLT score (Body Oxygen Level Test): after a normal exhale, time how long until you feel the first urge to breathe. Most untrained people score 15-20 seconds. Patrick McKeown\u{2019}s Buteyko training aims for 40+. The improvement curve is steep \u{2014} a few weeks of reduced-volume breathing can add 10-15 seconds to your BOLT score. Breath-hold training \u{2014} from simple exhale holds to freediver CO\u{2082} tables \u{2014} is the most direct way to retrain these chemoreceptors. Even a few weeks of structured practice can shift your CO\u{2082} alarm threshold significantly."
                 ),
                 Article(
                     id: 7,
@@ -186,6 +190,51 @@ enum LearnContent {
                     tagColorHex: "5A6E3D",
                     readTime: "4 min",
                     body: "The minimum effective dose is remarkably small. Five minutes of Resonance breathing (5.5 in, 5.5 out) produces a measurable HRV increase that lasts 30-60 minutes after the session. Two sessions per day \u{2014} morning and evening \u{2014} create a training effect that accumulates over weeks. By week 4, most practitioners notice: lower resting heart rate (2-5 bpm), longer BOLT score (+5-15 seconds), reduced sleep onset time, and a subjective sense of calm that wasn\u{2019}t there before. The key insight from Nestor\u{2019}s reporting is that breathing is a skill, not a gift. Every human can learn to breathe optimally. The patterns in this app aren\u{2019}t exotic \u{2014} they\u{2019}re the natural rhythms your ancestors used. You\u{2019}re just remembering."
+                ),
+            ]
+        ),
+
+        // Chapter 5: The Breath Hold
+        Chapter(
+            id: 5,
+            title: "Chapter 5 \u{00b7} The Breath Hold",
+            subtitle: "The science of not breathing",
+            articles: [
+                Article(
+                    id: 12,
+                    title: "Full lungs or empty?\nThe hold that matters.",
+                    subtitle: "Why the type of breath hold changes everything",
+                    tag: "Physiology",
+                    tagColorHex: "7A6030",
+                    readTime: "5 min",
+                    body: "Not all breath holds are equal. A full-lung hold (at total lung capacity) and an empty-lung hold (after a passive exhale, at functional residual capacity) produce fundamentally different training stimuli. Full-lung holds are easier and longer because stretch receptors in the lungs suppress the urge to breathe. The diaphragm is relaxed, the chest is expanded, and there is a large reservoir of oxygen to draw from. This is why beginners instinctively gulp air before holding. But the training effect is limited \u{2014} you are mostly testing oxygen stores, not CO\u{2082} tolerance. Empty-lung holds are harder and shorter, but far more effective for chemoreceptor training. With less oxygen available, CO\u{2082} rises faster. The urge to breathe arrives sooner and more intensely, which is precisely the stimulus that recalibrates your body\u{2019}s CO\u{2082} alarm threshold. This is why the BOLT test is measured after a passive exhale, not after a full inhale \u{2014} it tests your tolerance to CO\u{2082}, not the size of your lungs. The Bohr Effect connects both: higher CO\u{2082} during an empty-lung hold causes haemoglobin to release oxygen more readily to tissues. You are training your body to work efficiently with less air, which is the entire foundation of Buteyko\u{2019}s method. For most practitioners, empty-lung holds after gentle breathing are the priority. Full-lung holds have their place in freediving training, but for improving everyday breathing, the empty-lung hold is the one that matters."
+                ),
+                Article(
+                    id: 13,
+                    title: "The dive reflex\nyou didn\u{2019}t know you had",
+                    subtitle: "Bradycardia, vasoconstriction, and the Bajau spleen",
+                    tag: "Evolution",
+                    tagColorHex: "2D5F5D",
+                    readTime: "5 min",
+                    body: "Every human carries an ancient survival mechanism called the mammalian dive reflex. It activates during breath holds \u{2014} especially when cold water contacts the face \u{2014} and it has four remarkable components. First, apnea itself triggers the sequence. The moment you stop breathing, your body begins preparing for oxygen conservation. Second, bradycardia: your heart rate drops 10\u{2013}25%, sometimes more. This is involuntary \u{2014} even experienced freedivers cannot override it. The vagus nerve slows the heart to reduce oxygen consumption. Third, peripheral vasoconstriction. Blood vessels in your extremities constrict, shunting blood toward your brain and heart \u{2014} the organs that cannot survive without oxygen. Your fingers and toes get cold, but your core stays oxygenated. Fourth, splenic contraction. Your spleen squeezes out stored red blood cells, temporarily increasing your blood\u{2019}s oxygen-carrying capacity by up to 6%. The Bajau people of Southeast Asia \u{2014} a community of sea nomads who have been free-diving for thousands of years \u{2014} have spleens approximately 50% larger than neighbouring non-diving populations. Genetic analysis published in Cell in 2018 confirmed this is natural selection, not acclimatisation \u{2014} a variant in the PDE10A gene is responsible. Trained freedivers show a more pronounced dive reflex than untrained people, suggesting the response is both innate and trainable. Even simple breath-hold practice on dry land activates a mild version of this reflex. Cold face immersion amplifies it dramatically \u{2014} this is why splashing cold water on your face during a panic attack works. You are triggering the same vagal bradycardia that slows a diving seal\u{2019}s heart."
+                ),
+                Article(
+                    id: 14,
+                    title: "Your spleen is a scuba tank",
+                    subtitle: "The organ that gives you extra oxygen on demand",
+                    tag: "Surprising",
+                    tagColorHex: "C4502A",
+                    readTime: "4 min",
+                    body: "Your spleen is doing something remarkable that most people never learn about. This fist-sized organ in your upper left abdomen stores a reserve of red blood cells \u{2014} and during a breath hold, it contracts to release them into your bloodstream. The effect is measurable: hematocrit (the percentage of blood that is red blood cells) increases by 2\u{2013}6% within seconds of splenic contraction. More red blood cells means more haemoglobin, which means more oxygen-carrying capacity. Your body is giving itself a blood transfusion. The trigger is the sympathetic nervous system responding to apnea. As CO\u{2082} rises and oxygen falls, adrenaline causes the smooth muscle surrounding the spleen to contract. The stored red blood cells flood into circulation, buying you extra time before hypoxia becomes dangerous. The Bajau people of Southeast Asia have been diving for fish for thousands of years, and their spleens are roughly 50% larger than those of their land-dwelling neighbours. A 2018 study in Cell found a genetic variant (PDE10A) responsible for this enlargement \u{2014} genuine natural selection for diving ability, occurring over perhaps a thousand generations. Trained freedivers show more pronounced splenic contraction than untrained individuals, even during dry breath holds. The adaptation is partly genetic but also partly trainable \u{2014} regular apnea practice appears to enhance the response. However, the effect is temporary. Once you resume breathing, the spleen re-sequesters its red blood cells within minutes. This is not a permanent increase in oxygen capacity \u{2014} it is an emergency reserve, evolved for exactly the situation your body thinks it is in when you hold your breath. The takeaway is both humbling and awe-inspiring: your body has a built-in oxygen reserve that most people never activate. Even a few weeks of structured breath-hold training begins to awaken this ancient mechanism."
+                ),
+                Article(
+                    id: 15,
+                    title: "How freedivers hold their breath\nfor 10 minutes",
+                    subtitle: "CO\u{2082} tables, O\u{2082} tables, and the 80% mental rule",
+                    tag: "Extreme",
+                    tagColorHex: "C4502A",
+                    readTime: "6 min",
+                    body: "The current static apnea world record exceeds 11 minutes. This is not a genetic gift \u{2014} it is trained. Competitive freedivers use two primary table protocols to systematically extend their breath-hold capacity. CO\u{2082} tables keep the hold duration fixed while progressively shortening the rest period between holds. This means CO\u{2082} never fully clears between rounds, forcing the chemoreceptors to tolerate progressively higher levels. Over weeks, the CO\u{2082} alarm threshold shifts upward. O\u{2082} tables are the inverse: rest periods stay constant while hold durations increase. This primarily trains the body\u{2019}s tolerance to falling oxygen levels and builds the psychological confidence to sit with discomfort. Most freedivers consider apnea to be 80% mental. The physiological urge to breathe \u{2014} diaphragm contractions, rising chest pressure \u{2014} is uncomfortable but not dangerous for trained individuals operating within safe limits. The mental techniques are remarkably specific: body scanning (systematically relaxing each muscle group to reduce oxygen consumption), visualisation (imagining a calm scene to prevent panic), segmented thinking (breaking a long hold into 30-second blocks rather than contemplating the total duration), and mantras (simple repeated phrases that occupy the mind). Relaxation is the master skill. A tense body consumes oxygen far faster than a relaxed one. Elite freedivers achieve heart rates of 20\u{2013}30 BPM during static holds \u{2014} not through effort, but through deep parasympathetic activation. Some advanced freedivers use lung packing (also called carping) \u{2014} using the glottis to force additional air into already-full lungs. This can increase total lung volume by 1\u{2013}2 litres but carries serious risks including lung squeeze and pneumomediastinum. It should never be attempted without expert supervision. The safety rules are absolute: never practise breath holds in water without a trained buddy, never hold your breath after hyperventilating (this depletes CO\u{2082} and eliminates the warning urge to breathe, risking shallow-water blackout), and always stop if you feel tingling, warmth, or visual disturbances. For the average user, the goal is not a 10-minute hold. It is a BOLT score above 40 and the calm, efficient breathing that comes with it. The freediver\u{2019}s techniques \u{2014} CO\u{2082} tables, relaxation, and progressive training \u{2014} are the same principles, scaled to everyday life."
                 ),
             ]
         ),

--- a/Sources/SocraticJournal/Presentation/Learn/LearnView.swift
+++ b/Sources/SocraticJournal/Presentation/Learn/LearnView.swift
@@ -120,7 +120,7 @@ public struct LearnView: View {
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textSecondary)
 
-            Text("\(totalRead) of 12 read")
+            Text("\(totalRead) of \(LearnContent.allArticles.count) read")
                 .font(.system(size: 11))
                 .foregroundStyle(AppColors.accent)
                 .padding(.top, 2)

--- a/Sources/SocraticJournal/Presentation/Training/TrainingData.swift
+++ b/Sources/SocraticJournal/Presentation/Training/TrainingData.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Defines the 4 training exercises and their step structures
+/// Defines the 8 training exercises and their step structures
 enum TrainingData {
 
     // MARK: - Types
@@ -33,9 +33,35 @@ enum TrainingData {
         let steps: [Step]
     }
 
+    struct Section: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String
+        let exercises: [Exercise]
+    }
+
+    // MARK: - Sections
+
+    static let allSections: [Section] = [
+        Section(
+            id: "basics",
+            title: "Basics",
+            subtitle: "Foundation exercises for better breathing",
+            exercises: [noseUnblocking, breathAwareness, mouthTapeReadiness, co2Builder]
+        ),
+        Section(
+            id: "co2_tolerance",
+            title: "CO\u{2082} Tolerance",
+            subtitle: "Freediver-inspired protocols for chemoreceptor training",
+            exercises: [altitudeHold, co2Table, breathHoldWalk, apneaPyramid]
+        ),
+    ]
+
     // MARK: - All Exercises
 
-    static let allExercises: [Exercise] = [noseUnblocking, breathAwareness, mouthTapeReadiness, co2Builder]
+    static var allExercises: [Exercise] {
+        allSections.flatMap(\.exercises)
+    }
 
     // MARK: - Exercise 1: Nose Unblocking
 
@@ -117,6 +143,175 @@ enum TrainingData {
             steps.append(Step(id: stepId, type: .timerCountUp(
                 text: "Hold after the exhale \u{2014} tap when you feel the first urge to breathe",
                 maxSeconds: 60, tapToStop: true)))
+            stepId += 1
+        }
+        steps.append(Step(id: stepId, type: .result))
+        return steps
+    }
+
+    // MARK: - Exercise 5: High Altitude Breath Hold
+
+    static let altitudeHold = Exercise(
+        id: "altitude_hold",
+        name: "High Altitude Hold",
+        icon: "mountain.2",
+        duration: "6 min",
+        description: "Simulates the hypoxic-hypercapnic conditions of high altitude (4,000\u{2013}5,000m). A 4-second nasal inhale, 2-second hold, slow exhale, then hold after exhale for as long as comfortable. Five rounds with recovery breathing between each. Trains both CO\u{2082} and O\u{2082} tolerance simultaneously.",
+        steps: altitudeHoldSteps()
+    )
+
+    private static func altitudeHoldSteps() -> [Step] {
+        var steps: [Step] = []
+        var stepId = 0
+        steps.append(Step(id: stepId, type: .instruction(
+            text: "This exercise simulates high-altitude breathing. You\u{2019}ll do 5 rounds of: inhale, brief hold, exhale, then hold after exhale as long as comfortable.",
+            autoAdvanceSeconds: 6)))
+        stepId += 1
+        for round in 1...5 {
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Round \(round) of 5 \u{2014} Breathe in through your nose",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Hold",
+                seconds: 2, showPanicButton: false)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Slow exhale through your nose",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .timerCountUp(
+                text: "Hold after exhale \u{2014} tap when you need to breathe",
+                maxSeconds: 90, tapToStop: true)))
+            stepId += 1
+            if round < 5 {
+                steps.append(Step(id: stepId, type: .timerCountdown(
+                    text: "Recovery breathing \u{2014} gentle nasal breaths",
+                    seconds: 15, showPanicButton: false)))
+                stepId += 1
+            }
+        }
+        steps.append(Step(id: stepId, type: .result))
+        return steps
+    }
+
+    // MARK: - Exercise 6: CO₂ Table
+
+    static let co2Table = Exercise(
+        id: "co2_table",
+        name: "CO\u{2082} Table",
+        icon: "chart.bar.xaxis.ascending",
+        duration: "7 min",
+        description: "A classic freediver CO\u{2082} desensitisation protocol. Eight rounds of a fixed 20-second breath hold with rest periods that shrink from 40 seconds down to 5. The decreasing rest means CO\u{2082} accumulates across the session, progressively challenging your chemoreceptors.",
+        steps: co2TableSteps()
+    )
+
+    private static func co2TableSteps() -> [Step] {
+        let restPeriods: [TimeInterval] = [40, 35, 30, 25, 20, 15, 10, 5]
+        var steps: [Step] = []
+        var stepId = 0
+        steps.append(Step(id: stepId, type: .instruction(
+            text: "Stop immediately if you feel dizzy, see spots, or feel tingling in your extremities. Never practise breath holds in water.",
+            autoAdvanceSeconds: 6)))
+        stepId += 1
+        for round in 0..<8 {
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Recovery breathing \u{2014} Round \(round + 1) of 8 (\(Int(restPeriods[round]))s rest)",
+                seconds: restPeriods[round], showPanicButton: false)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Take a normal breath in\u{2026} and out",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Hold \u{2014} Round \(round + 1) of 8",
+                seconds: 20, showPanicButton: true)))
+            stepId += 1
+        }
+        steps.append(Step(id: stepId, type: .ratingScale(
+            question: "How did the last round feel?",
+            count: 5, lowLabel: "Desperate", highLabel: "Comfortable")))
+        stepId += 1
+        steps.append(Step(id: stepId, type: .result))
+        return steps
+    }
+
+    // MARK: - Exercise 7: Breath-Hold Walk
+
+    static let breathHoldWalk = Exercise(
+        id: "breathhold_walk",
+        name: "Breath-Hold Walk",
+        icon: "figure.walk",
+        duration: "8 min",
+        description: "Patrick McKeown\u{2019}s Oxygen Advantage exercise. After a gentle exhale, hold your breath and walk, counting steps. Movement during holds is more effective than static holds for improving your BOLT score because it increases metabolic CO\u{2082} production.",
+        steps: breathHoldWalkSteps()
+    )
+
+    private static func breathHoldWalkSteps() -> [Step] {
+        var steps: [Step] = []
+        var stepId = 0
+        steps.append(Step(id: stepId, type: .instruction(
+            text: "You\u{2019}ll hold your breath after a gentle exhale and walk, counting your steps. Start easy \u{2014} your goal is to add a few steps each round.",
+            autoAdvanceSeconds: 6)))
+        stepId += 1
+        for round in 1...6 {
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Round \(round) of 6 \u{2014} Breathe normally for 30 seconds",
+                autoAdvanceSeconds: 3)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Normal nasal breathing",
+                seconds: 30, showPanicButton: false)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Gentle breath in\u{2026} and out. Pinch your nose.",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .tapCounter(
+                text: "Walk and tap each step \u{2014} stop when you need to breathe",
+                seconds: 60)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Resume gentle nasal breathing",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+        }
+        steps.append(Step(id: stepId, type: .result))
+        return steps
+    }
+
+    // MARK: - Exercise 8: Apnea Pyramid
+
+    static let apneaPyramid = Exercise(
+        id: "apnea_pyramid",
+        name: "Apnea Pyramid",
+        icon: "triangle",
+        duration: "8 min",
+        description: "A freediving dry static pyramid: holds gradually increase to a peak then decrease. The ascending half builds confidence, the peak challenges your limit, and the descending half provides psychological relief. All holds are after a normal exhale.",
+        steps: apneaPyramidSteps()
+    )
+
+    private static func apneaPyramidSteps() -> [Step] {
+        let holdDurations: [TimeInterval] = [10, 15, 20, 25, 30, 25, 20, 15, 10]
+        var steps: [Step] = []
+        var stepId = 0
+        steps.append(Step(id: stepId, type: .instruction(
+            text: "A pyramid of breath holds \u{2014} building up, then easing down. All holds are after a normal exhale.",
+            autoAdvanceSeconds: 5)))
+        stepId += 1
+        for (index, holdSeconds) in holdDurations.enumerated() {
+            let round = index + 1
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Recovery breathing \u{2014} Round \(round) of 9",
+                seconds: 20, showPanicButton: false)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .instruction(
+                text: "Normal breath in\u{2026} and out",
+                autoAdvanceSeconds: 4)))
+            stepId += 1
+            steps.append(Step(id: stepId, type: .timerCountdown(
+                text: "Hold \u{2014} \(Int(holdSeconds))s",
+                seconds: holdSeconds, showPanicButton: holdSeconds >= 25)))
             stepId += 1
         }
         steps.append(Step(id: stepId, type: .result))

--- a/Sources/SocraticJournal/Presentation/Training/TrainingFlowView.swift
+++ b/Sources/SocraticJournal/Presentation/Training/TrainingFlowView.swift
@@ -323,6 +323,14 @@ struct TrainingFlowView: View {
                     mouthTapeResult
                 } else if viewModel.exercise.id == "co2_builder" {
                     co2BuilderResult
+                } else if viewModel.exercise.id == "altitude_hold" {
+                    altitudeHoldResult
+                } else if viewModel.exercise.id == "co2_table" {
+                    co2TableResult
+                } else if viewModel.exercise.id == "breathhold_walk" {
+                    breathHoldWalkResult
+                } else if viewModel.exercise.id == "apnea_pyramid" {
+                    apneaPyramidResult
                 } else {
                     noseUnblockingResult
                 }
@@ -453,6 +461,78 @@ struct TrainingFlowView: View {
             Text("Your average (\(String(format: "%.1f", viewModel.averageHoldTime))s) suggests a BOLT score in the \(tier.label) range")
                 .font(.system(size: 11))
                 .foregroundStyle(AppColors.textTertiary)
+        }
+    }
+
+    private var altitudeHoldResult: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            Text("Your 5 Holds")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundStyle(AppColors.textPrimary)
+
+            ForEach(Array(viewModel.holdTimes.enumerated()), id: \.offset) { index, time in
+                HStack {
+                    Text("Round \(index + 1)")
+                        .font(.system(size: 13))
+                        .foregroundStyle(AppColors.textTertiary)
+                    Spacer()
+                    Text(String(format: "%.1fs", time))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(AppColors.textPrimary)
+                }
+            }
+
+            HairlineDivider()
+
+            HStack {
+                Text("Average")
+                    .font(.system(size: 13))
+                    .foregroundStyle(AppColors.textTertiary)
+                Spacer()
+                Text(String(format: "%.1fs", viewModel.averageHoldTime))
+                    .font(.system(size: 15, weight: .bold, design: .serif))
+                    .foregroundStyle(AppColors.accent)
+            }
+
+            resultCard("High-altitude holds train both CO\u{2082} and O\u{2082} tolerance simultaneously. Consistent practice builds the dual stimulus that pure CO\u{2082} exercises miss.", colorHex: "2D5F5D")
+        }
+    }
+
+    private var co2TableResult: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            Text("CO\u{2082} Table Complete")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundStyle(AppColors.textPrimary)
+
+            if viewModel.ratingValue >= 4 {
+                resultCard("You handled the shrinking rest periods well. Your chemoreceptors are adapting to higher CO\u{2082} levels. Try this 2\u{2013}3 times per week.", colorHex: "2D5F5D")
+            } else if viewModel.ratingValue >= 2 {
+                resultCard("Moderate difficulty is expected \u{2014} the last few rounds are designed to push your CO\u{2082} threshold. This gets easier with regular practice.", colorHex: "7A6030")
+            } else {
+                resultCard("The final rounds were very challenging. This is normal for beginners. Your chemoreceptors will adapt over 2\u{2013}3 weeks of regular practice.", colorHex: "C4502A")
+            }
+        }
+    }
+
+    private var breathHoldWalkResult: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            Text("Your 6 Walks")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundStyle(AppColors.textPrimary)
+
+            // tapCount for each round is not tracked per-round in the current ViewModel,
+            // so we show overall completion
+            resultCard("Walking during breath holds increases metabolic CO\u{2082} production, making each hold more effective than a static equivalent. Patrick McKeown considers this the single best exercise for improving your BOLT score.", colorHex: "2D5F5D")
+        }
+    }
+
+    private var apneaPyramidResult: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            Text("Pyramid Complete")
+                .font(.system(size: 18, weight: .bold, design: .serif))
+                .foregroundStyle(AppColors.textPrimary)
+
+            resultCard("The pyramid structure builds confidence on the way up and provides relief on the way down. The peak round (30s) is your current challenge threshold. As this gets easier, you can extend all durations.", colorHex: "2D5F5D")
         }
     }
 

--- a/Tests/SocraticJournalTests/Domain/BOLTScoreTests.swift
+++ b/Tests/SocraticJournalTests/Domain/BOLTScoreTests.swift
@@ -111,6 +111,51 @@ struct BOLTScoreTests {
         #expect(decoded.score == score.score)
     }
 
+    // MARK: - BOLTScore Properties
+
+    @Suite("BOLTScore Properties")
+    struct BOLTScorePropertyTests {
+
+        @Test("BOLTScore initializer sets correct defaults")
+        func initializerDefaults() {
+            let score = BOLTScore(score: 25.0)
+            #expect(!score.id.isEmpty)
+            #expect(score.score == 25.0)
+        }
+
+        @Test("BOLTScore.tier returns correct tier")
+        func tierComputed() {
+            let score5 = BOLTScore(score: 5.0)
+            #expect(score5.tier == .veryLow)
+
+            let score15 = BOLTScore(score: 15.0)
+            #expect(score15.tier == .belowAverage)
+
+            let score25 = BOLTScore(score: 25.0)
+            #expect(score25.tier == .average)
+
+            let score35 = BOLTScore(score: 35.0)
+            #expect(score35.tier == .good)
+
+            let score45 = BOLTScore(score: 45.0)
+            #expect(score45.tier == .excellent)
+        }
+
+        @Test("Trend symbols are correct")
+        func trendSymbols() {
+            #expect(BOLTTier.TrendDirection.improved.symbol == "\u{2191}")
+            #expect(BOLTTier.TrendDirection.declined.symbol == "\u{2193}")
+            #expect(BOLTTier.TrendDirection.same.symbol == "\u{2192}")
+        }
+
+        @Test("Trend colors are correct")
+        func trendColors() {
+            #expect(BOLTTier.TrendDirection.improved.colorHex == "5A6E3D")
+            #expect(BOLTTier.TrendDirection.declined.colorHex == "C4502A")
+            #expect(BOLTTier.TrendDirection.same.colorHex == "7A6E60")
+        }
+    }
+
     // MARK: - Trend
 
     @Suite("Trend Calculation")

--- a/Tests/SocraticJournalTests/Domain/BreathPatternTests.swift
+++ b/Tests/SocraticJournalTests/Domain/BreathPatternTests.swift
@@ -120,4 +120,49 @@ struct BreathPatternTests {
         #expect(BreathPattern.tummo.difficulty == .advanced)
         #expect(BreathPattern.alternateNostril.difficulty == .intermediate)
     }
+
+    @Test("Each pattern has at least 1 phase")
+    func patternsHavePhases() {
+        for pattern in BreathPattern.allPatterns {
+            #expect(!pattern.phases.isEmpty, "Pattern \(pattern.id) has no phases")
+        }
+    }
+
+    @Test("All phase durations are greater than 0")
+    func phaseDurationsPositive() {
+        for pattern in BreathPattern.allPatterns {
+            for phase in pattern.phases {
+                #expect(phase.duration > 0, "Pattern \(pattern.id) phase \(phase.id) has duration <= 0")
+            }
+        }
+    }
+
+    @Test("All patterns have non-empty name, timing, bpm, tag")
+    func patternFieldsNonEmpty() {
+        for pattern in BreathPattern.allPatterns {
+            #expect(!pattern.name.isEmpty, "Pattern \(pattern.id) has empty name")
+            #expect(!pattern.timing.isEmpty, "Pattern \(pattern.id) has empty timing")
+            #expect(!pattern.bpm.isEmpty, "Pattern \(pattern.id) has empty bpm")
+            #expect(!pattern.tag.isEmpty, "Pattern \(pattern.id) has empty tag")
+        }
+    }
+
+    @Test("All tagColorHex values are valid 6-character hex strings")
+    func tagColorHexValid() {
+        let hexChars = CharacterSet(charactersIn: "0123456789ABCDEFabcdef")
+        for pattern in BreathPattern.allPatterns {
+            #expect(pattern.tagColorHex.count == 6,
+                    "Pattern \(pattern.id) tagColorHex is not 6 chars: \(pattern.tagColorHex)")
+            #expect(pattern.tagColorHex.unicodeScalars.allSatisfy { hexChars.contains($0) },
+                    "Pattern \(pattern.id) has invalid hex chars: \(pattern.tagColorHex)")
+        }
+    }
+
+    @Test("cycleDuration equals sum of phase durations for each pattern")
+    func cycleDurationEqualsSum() {
+        for pattern in BreathPattern.allPatterns {
+            let sum = pattern.phases.reduce(0.0) { $0 + $1.duration }
+            #expect(pattern.cycleDuration == sum, "Pattern \(pattern.id) cycleDuration mismatch")
+        }
+    }
 }

--- a/Tests/SocraticJournalTests/Learn/LearnContentChapter5Tests.swift
+++ b/Tests/SocraticJournalTests/Learn/LearnContentChapter5Tests.swift
@@ -1,0 +1,71 @@
+// LearnContentChapter5Tests.swift
+// SocraticJournalTests
+// Copyright 2024 StudioNext
+
+import Testing
+import Foundation
+@testable import SocraticJournal
+
+@Suite("LearnContent Chapter 5 Tests")
+struct LearnContentChapter5Tests {
+
+    @Test("Chapter 5 exists with id 5")
+    func chapter5Exists() {
+        let chapter = LearnContent.chapters.first { $0.id == 5 }
+        #expect(chapter != nil)
+    }
+
+    @Test("Chapter 5 has exactly 4 articles")
+    func chapter5ArticleCount() {
+        let chapter = LearnContent.chapters.first { $0.id == 5 }!
+        #expect(chapter.articles.count == 4)
+    }
+
+    @Test("Article IDs are sequential (12, 13, 14, 15)")
+    func articleIDsSequential() {
+        let chapter = LearnContent.chapters.first { $0.id == 5 }!
+        let ids = chapter.articles.map(\.id)
+        #expect(ids == [12, 13, 14, 15])
+    }
+
+    @Test("All Chapter 5 articles have non-empty required fields")
+    func articleFieldsNonEmpty() {
+        let chapter = LearnContent.chapters.first { $0.id == 5 }!
+        for article in chapter.articles {
+            #expect(!article.title.isEmpty, "Article \(article.id) has empty title")
+            #expect(!article.subtitle.isEmpty, "Article \(article.id) has empty subtitle")
+            #expect(!article.tag.isEmpty, "Article \(article.id) has empty tag")
+            #expect(!article.tagColorHex.isEmpty, "Article \(article.id) has empty tagColorHex")
+            #expect(!article.readTime.isEmpty, "Article \(article.id) has empty readTime")
+            #expect(!article.body.isEmpty, "Article \(article.id) has empty body")
+        }
+    }
+
+    @Test("Total article count is 16 (12 existing + 4 new)")
+    func totalArticleCount() {
+        #expect(LearnContent.allArticles.count == 16)
+    }
+
+    @Test("All article IDs across all chapters are globally unique")
+    func articleIDsGloballyUnique() {
+        let allIDs = LearnContent.allArticles.map(\.id)
+        let uniqueIDs = Set(allIDs)
+        #expect(allIDs.count == uniqueIDs.count)
+    }
+
+    @Test("All tagColorHex values are valid 6-character hex strings")
+    func tagColorHexValid() {
+        let hexChars = CharacterSet(charactersIn: "0123456789ABCDEFabcdef")
+        for article in LearnContent.allArticles {
+            #expect(article.tagColorHex.count == 6,
+                    "Article \(article.id) tagColorHex is not 6 chars: \(article.tagColorHex)")
+            #expect(article.tagColorHex.unicodeScalars.allSatisfy { hexChars.contains($0) },
+                    "Article \(article.id) has invalid hex chars: \(article.tagColorHex)")
+        }
+    }
+
+    @Test("Quick facts count is 12 (8 existing + 4 new)")
+    func quickFactsCount() {
+        #expect(LearnContent.quickFacts.count == 12)
+    }
+}

--- a/Tests/SocraticJournalTests/Mocks/MockBreathSessionRepository.swift
+++ b/Tests/SocraticJournalTests/Mocks/MockBreathSessionRepository.swift
@@ -94,6 +94,25 @@ public final class MockBreathSessionRepository: BreathSessionRepositoryProtocol,
         return boltScores.max(by: { $0.recordedAt < $1.recordedAt })
     }
 
+    // MARK: - Sample Data
+
+    private var sampleDataAdded: Bool = false
+
+    public func addSampleData() async throws {
+        if shouldFail { throw failError }
+        sampleDataAdded = true
+    }
+
+    public func removeSampleData() async throws {
+        if shouldFail { throw failError }
+        sampleDataAdded = false
+    }
+
+    public func hasSampleData() async throws -> Bool {
+        if shouldFail { throw failError }
+        return sampleDataAdded
+    }
+
     // MARK: - Test Helpers
 
     public func reset() {

--- a/Tests/SocraticJournalTests/Training/TrainingDataTests.swift
+++ b/Tests/SocraticJournalTests/Training/TrainingDataTests.swift
@@ -1,0 +1,101 @@
+// TrainingDataTests.swift
+// SocraticJournalTests
+// Copyright 2024 StudioNext
+
+import Testing
+import Foundation
+@testable import SocraticJournal
+
+@Suite("TrainingData Tests")
+struct TrainingDataTests {
+
+    @Test("All 8 exercises exist")
+    func allExercisesCount() {
+        #expect(TrainingData.allExercises.count == 8)
+    }
+
+    @Test("All exercise IDs are unique")
+    func exerciseIDsUnique() {
+        let ids = TrainingData.allExercises.map(\.id)
+        let uniqueIDs = Set(ids)
+        #expect(ids.count == uniqueIDs.count)
+    }
+
+    @Test("All exercises have non-empty name, icon, duration, description")
+    func exerciseFieldsNonEmpty() {
+        for exercise in TrainingData.allExercises {
+            #expect(!exercise.name.isEmpty, "Exercise \(exercise.id) has empty name")
+            #expect(!exercise.icon.isEmpty, "Exercise \(exercise.id) has empty icon")
+            #expect(!exercise.duration.isEmpty, "Exercise \(exercise.id) has empty duration")
+            #expect(!exercise.description.isEmpty, "Exercise \(exercise.id) has empty description")
+        }
+    }
+
+    @Test("Every exercise ends with a result step")
+    func exercisesEndWithResult() {
+        for exercise in TrainingData.allExercises {
+            guard let lastStep = exercise.steps.last else {
+                Issue.record("Exercise \(exercise.id) has no steps")
+                continue
+            }
+            if case .result = lastStep.type {
+                // correct
+            } else {
+                Issue.record("Exercise \(exercise.id) does not end with .result step")
+            }
+        }
+    }
+
+    @Test("Step IDs within each exercise are sequential from 0")
+    func stepIDsSequential() {
+        for exercise in TrainingData.allExercises {
+            let ids = exercise.steps.map(\.id)
+            let expected = Array(0..<exercise.steps.count)
+            #expect(ids == expected, "Exercise \(exercise.id) has non-sequential step IDs")
+        }
+    }
+
+    @Test("No exercise has zero steps")
+    func noEmptyExercises() {
+        for exercise in TrainingData.allExercises {
+            #expect(!exercise.steps.isEmpty, "Exercise \(exercise.id) has zero steps")
+        }
+    }
+
+    // MARK: - Round Counts
+
+    @Test("CO2 Builder has 5 rounds (16 steps total)")
+    func co2BuilderRounds() {
+        let exercise = TrainingData.allExercises.first { $0.id == "co2_builder" }!
+        // 5 rounds x 3 steps + 1 result = 16
+        #expect(exercise.steps.count == 16)
+    }
+
+    @Test("Altitude Hold has 5 rounds")
+    func altitudeHoldRounds() {
+        let exercise = TrainingData.allExercises.first { $0.id == "altitude_hold" }!
+        // 1 intro + 5 rounds x 4 steps + 4 recovery + 1 result = 26
+        #expect(exercise.steps.count == 26)
+    }
+
+    @Test("CO2 Table has 8 rounds")
+    func co2TableRounds() {
+        let exercise = TrainingData.allExercises.first { $0.id == "co2_table" }!
+        // 1 safety + 8 rounds x 3 steps + 1 rating + 1 result = 27
+        #expect(exercise.steps.count == 27)
+    }
+
+    @Test("Apnea Pyramid has 9 hold rounds")
+    func apneaPyramidRounds() {
+        let exercise = TrainingData.allExercises.first { $0.id == "apnea_pyramid" }!
+        // 1 intro + 9 rounds x 3 steps + 1 result = 29
+        #expect(exercise.steps.count == 29)
+    }
+
+    @Test("Breath-Hold Walk has 6 rounds")
+    func breathHoldWalkRounds() {
+        let exercise = TrainingData.allExercises.first { $0.id == "breathhold_walk" }!
+        // 1 intro + 6 rounds x 5 steps + 1 result = 32
+        #expect(exercise.steps.count == 32)
+    }
+}

--- a/Tests/SocraticJournalTests/Training/TrainingPersistenceTests.swift
+++ b/Tests/SocraticJournalTests/Training/TrainingPersistenceTests.swift
@@ -1,0 +1,75 @@
+// TrainingPersistenceTests.swift
+// SocraticJournalTests
+// Copyright 2024 StudioNext
+
+import Testing
+import Foundation
+@testable import SocraticJournal
+
+@Suite("TrainingData Persistence Tests")
+struct TrainingPersistenceTests {
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "com.breathe.test.\(UUID().uuidString)"
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    @Test("Initial completion count is 0")
+    func initialCountIsZero() {
+        let defaults = makeDefaults()
+        let count = TrainingData.completionCount(for: "nose_unblocking", defaults: defaults)
+        #expect(count == 0)
+    }
+
+    @Test("After one increment, count is 1")
+    func singleIncrement() {
+        let defaults = makeDefaults()
+        TrainingData.incrementCompletion(for: "nose_unblocking", defaults: defaults)
+        let count = TrainingData.completionCount(for: "nose_unblocking", defaults: defaults)
+        #expect(count == 1)
+    }
+
+    @Test("After 3 increments, count is 3")
+    func tripleIncrement() {
+        let defaults = makeDefaults()
+        for _ in 0..<3 {
+            TrainingData.incrementCompletion(for: "co2_builder", defaults: defaults)
+        }
+        let count = TrainingData.completionCount(for: "co2_builder", defaults: defaults)
+        #expect(count == 3)
+    }
+
+    @Test("Counts are independent per exercise ID")
+    func independentCounts() {
+        let defaults = makeDefaults()
+        TrainingData.incrementCompletion(for: "nose_unblocking", defaults: defaults)
+        TrainingData.incrementCompletion(for: "nose_unblocking", defaults: defaults)
+        TrainingData.incrementCompletion(for: "co2_builder", defaults: defaults)
+
+        #expect(TrainingData.completionCount(for: "nose_unblocking", defaults: defaults) == 2)
+        #expect(TrainingData.completionCount(for: "co2_builder", defaults: defaults) == 1)
+        #expect(TrainingData.completionCount(for: "altitude_hold", defaults: defaults) == 0)
+    }
+
+    @Test("Incrementing one exercise does not affect another")
+    func noSideEffects() {
+        let defaults = makeDefaults()
+        TrainingData.incrementCompletion(for: "altitude_hold", defaults: defaults)
+
+        #expect(TrainingData.completionCount(for: "altitude_hold", defaults: defaults) == 1)
+        #expect(TrainingData.completionCount(for: "co2_table", defaults: defaults) == 0)
+    }
+
+    @Test("Counts persist across separate calls")
+    func persistence() {
+        let defaults = makeDefaults()
+        TrainingData.incrementCompletion(for: "breathhold_walk", defaults: defaults)
+        // Read from same defaults instance
+        let count1 = TrainingData.completionCount(for: "breathhold_walk", defaults: defaults)
+        TrainingData.incrementCompletion(for: "breathhold_walk", defaults: defaults)
+        let count2 = TrainingData.completionCount(for: "breathhold_walk", defaults: defaults)
+
+        #expect(count1 == 1)
+        #expect(count2 == 2)
+    }
+}

--- a/Tests/SocraticJournalTests/Training/TrainingSectionsTests.swift
+++ b/Tests/SocraticJournalTests/Training/TrainingSectionsTests.swift
@@ -1,0 +1,57 @@
+// TrainingSectionsTests.swift
+// SocraticJournalTests
+// Copyright 2024 StudioNext
+
+import Testing
+import Foundation
+@testable import SocraticJournal
+
+@Suite("TrainingData Sections Tests")
+struct TrainingSectionsTests {
+
+    @Test("allSections has exactly 2 sections")
+    func sectionCount() {
+        #expect(TrainingData.allSections.count == 2)
+    }
+
+    @Test("Basics section contains exactly 4 exercises")
+    func basicsSectionCount() {
+        let basics = TrainingData.allSections.first { $0.id == "basics" }
+        #expect(basics != nil)
+        #expect(basics!.exercises.count == 4)
+    }
+
+    @Test("CO2 Tolerance section contains exactly 4 exercises")
+    func co2SectionCount() {
+        let co2 = TrainingData.allSections.first { $0.id == "co2_tolerance" }
+        #expect(co2 != nil)
+        #expect(co2!.exercises.count == 4)
+    }
+
+    @Test("allExercises computed property returns all 8 exercises")
+    func allExercisesBackwardCompat() {
+        #expect(TrainingData.allExercises.count == 8)
+    }
+
+    @Test("Section titles and subtitles are non-empty")
+    func sectionFieldsNonEmpty() {
+        for section in TrainingData.allSections {
+            #expect(!section.title.isEmpty, "Section \(section.id) has empty title")
+            #expect(!section.subtitle.isEmpty, "Section \(section.id) has empty subtitle")
+        }
+    }
+
+    @Test("Each section has unique id")
+    func sectionIDsUnique() {
+        let ids = TrainingData.allSections.map(\.id)
+        let uniqueIDs = Set(ids)
+        #expect(ids.count == uniqueIDs.count)
+    }
+
+    @Test("Exercise IDs across all sections are globally unique")
+    func exerciseIDsGloballyUnique() {
+        let allIDs = TrainingData.allSections.flatMap { $0.exercises.map(\.id) }
+        let uniqueIDs = Set(allIDs)
+        #expect(allIDs.count == uniqueIDs.count)
+    }
+}


### PR DESCRIPTION
## Summary

- **4 new training exercises** — High Altitude Hold, CO2 Table (freediver shrinking-rest protocol), Breath-Hold Walk (Oxygen Advantage step counting), and Apnea Pyramid (ascending/descending hold pyramid)
- **Exercises organized into sections** — "Basics" (existing 4) and "CO2 Tolerance" (new 4) with editorial-styled section headers and teal dividers in TrainingGrid
- **Chapter 5: "The Breath Hold"** — 4 new Learn articles covering full-lungs vs empty-lungs holds, the mammalian dive reflex, splenic contraction during apnea, and competitive freediving techniques
- **4 new quick facts** — BOLT 40s+, Bajau 50% larger spleens, 80% of apnea is mental, 10–25% heart rate drop in dive reflex
- **BOLT tier interpretations** updated with specific exercise recommendations per tier
- **Bridge text** appended to existing CO2 article (Article 6) connecting to breath-hold training
- **Hardcoded article count** in LearnView replaced with dynamic `allArticles.count`
- **6 new/updated test suites** — TrainingDataTests, TrainingSectionsTests, LearnContentChapter5Tests, TrainingPersistenceTests, BOLTScoreTests, BreathPatternTests

## Details

### New Exercises

| Exercise | Rounds | Protocol |
|----------|--------|----------|
| High Altitude Hold | 5 | 4s inhale → 2s hold → exhale → timed exhale-hold (max 90s) → 15s recovery |
| CO2 Table | 8 | Shrinking rest (40s→5s) → fixed 20s hold with panic button |
| Breath-Hold Walk | 6 | 30s recovery → exhale → walk counting steps (tapCounter, max 60s) |
| Apnea Pyramid | 9 | 20s recovery → exhale → holds [10,15,20,25,30,25,20,15,10]s |

### Chapter 5 Articles

1. **Full lungs or empty?** — Physiology of TLC vs FRC holds, Bohr Effect connection, why BOLT uses passive exhale
2. **The dive reflex you didn't know you had** — Apnea, bradycardia, vasoconstriction, splenic contraction, Bajau genetics
3. **Your spleen is a scuba tank** — Splenic contraction, hematocrit increase, PDE10A gene variant
4. **How freedivers hold their breath for 10 minutes** — CO2/O2 tables, mental techniques, safety rules

### Test Coverage

175 tests passing across 31 suites. New tests validate exercise structure, step sequencing, section grouping, article integrity, persistence, and pattern data.

## Test plan

- [ ] Run all 8 training exercises end-to-end in simulator — verify step flow, timers, panic buttons, and result screens
- [ ] Verify TrainingGrid shows two sections with headers ("Basics" / "CO2 Tolerance")
- [ ] Read all 4 Chapter 5 articles in Learn tab — verify content renders correctly
- [ ] Check Learn tab header shows "X of 16 read" (not "of 12")
- [ ] Take BOLT test and verify tier interpretation mentions new exercises
- [ ] Verify 12 quick facts appear in Learn tab
- [ ] Run `xcodebuild test` — all 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)